### PR TITLE
Replace 'npm run' with 'npx'

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,7 @@ const pathToTemplates = process.mainModule.filename
 const isYarn = process.env.npm_execpath.includes('yarn');
 
 const toExecute = `${
-  isYarn ? 'yarn' : 'npm run'
+  isYarn ? 'yarn' : 'npx'
 } nswag openapi2tsclient /templateDirectory:${pathToTemplates} ${args}`;
 exec(toExecute, function (e, stdout, stderr) {
   console.log(stdout);


### PR DESCRIPTION
Use npx instead of npm run so that it works without having a run script called nswag.