### PR TITLE
Handle Vue ref parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -522,6 +522,5 @@ src/templates_no_hooks/original/OperationNameSafe.liquid
 !/src/templates_vue/AxiosClient.liquid
 !/src/templates_vue/ReactQuery.MetaFile.liquid
 !/src/templates_vue/ReactQuery.MetaFileFunctions.liquid
-src/templates_vue/ReactQuery.liquid
 src/templates_no_hooks/ReactQuery.MetaFileFunctions.liquid
 src/templates_v3/ReactQuery.MetaFileFunctions.liquid

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate-api-client-no-hooks-no-modules": "yarn workspace pet-client generate-no-hooks-no-modules",
     "update-nswag": "node scripts/update-nswag-templates.mjs --experimental-fetch",
     "copy_from_v4_to_v3": "yarn copyfiles -u 2 -e \"src/templates/File.liquid\" -e \"src/templates/AxiosClient.liquid\" -e \"src/templates/FetchClient.liquid\" src/templates/**/* src/templates_v3 && yarn replace \"from '@tanstack/react-query';\" \"from 'react-query';\" src/templates_v3/ReactQueryFile.liquid",
-    "copy_from_v4_to_vue": "yarn copyfiles -u 2 -e \"src/templates/File.liquid\" -e \"src/templates/AxiosClient.liquid\" -e \"src/templates/FetchClient.liquid\" -e \"src/templates/ReactQuery.MetaFile*.liquid\" src/templates/**/* src/templates_vue",
+    "copy_from_v4_to_vue": "yarn copyfiles -u 2 -e \"src/templates/File.liquid\" -e \"src/templates/AxiosClient.liquid\" -e \"src/templates/FetchClient.liquid\" -e \"src/templates/ReactQuery.liquid\" -e \"src/templates/ReactQuery.MetaFile*.liquid\" src/templates/**/* src/templates_vue",
     "copy_to_no_hooks": "yarn copyfiles -u 2 -e \"src/templates/File.liquid\" -e \"src/templates/AxiosClient.liquid\" -e \"src/templates/FetchClient.liquid\" -e \"**/ReactQueryFile.liquid\" -e \"**/ReactQuery.liquid\" src/templates/**/* src/templates_no_hooks"
   },
   "devDependencies": {

--- a/src/templates_vue/ReactQuery.liquid
+++ b/src/templates_vue/ReactQuery.liquid
@@ -1,0 +1,188 @@
+{% template ClientFileHeader %}
+import { useQuery, useMutation } from '@tanstack/react-query';
+import type { Ref } from 'vue';
+import type { UseQueryResult, QueryFunctionContext, UseQueryOptions, QueryClient, QueryKey, MutationKey, UseMutationOptions, UseMutationResult, QueryMeta, MutationMeta } from '@tanstack/react-query';
+import { trimArrayEnd, isParameterObject, getBaseUrl, addMetaToOptions  } from './helpers';
+{% template ReactQuery.MetaFile %}
+{% template ReactQuery.GetClientFunction %}
+
+{%- if HasOperations -%}
+{%- assign QueryClassName = Class | prepend: 'Qqqqqq' | slice: 0, Class.size | append: "Query" | slice: 6, 1000 -%}
+{%- assign MutationClassName = Class | prepend: 'Qqqqqq' | slice: 0, Class.size | append: "Mutation" | slice: 6, 1000 -%}
+
+{%- for operation in Operations -%}
+{%- if operation.HttpMethodUpper == 'Get' -%}
+{%- if operation.Parameters.size > 0 -%}
+{%- assign firstLetter = operation.ActualOperationName | slice: 0, 1 | upcase -%}
+{%- assign parameterClassName = operation.ActualOperationName | append: 'q' | slice: 1, operation.ActualOperationName.size | prepend: firstLetter | slice: 0, operation.ActualOperationName.size | append: QueryClassName | append: 'Parameters' -%}
+export type {{ parameterClassName }} = {
+  {%- for parameter in operation.Parameters -%}
+  {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: Types.{{ parameter.Type }}{{ parameter.TypePostfix }} | Ref<Types.{{ parameter.Type }}{{ parameter.TypePostfix }}>;
+  {%- endfor -%}
+};
+
+{%- endif -%}
+{%- endif -%}
+{%- if operation.HttpMethodUpper <> 'Get' -%}
+{%- if operation.FormParameters.size > 0 -%}
+{%- assign firstLetter = operation.ActualOperationName | slice: 0, 1 | upcase -%}
+{%- assign parameterClassName = operation.ActualOperationName | append: 'q' | slice: 1, operation.ActualOperationName.size | prepend: firstLetter | slice: 0, operation.ActualOperationName.size | append: MutationClassName | append: 'Parameters' -%}
+export type {{ parameterClassName }} = {
+  {%- for parameter in operation.FormParameters -%}
+  {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: Types.{{ parameter.Type }}{{ parameter.TypePostfix }} ; {% comment %}space before the ';' is important, so that 'undefined' here is not replaced with null{% endcomment %}
+  {%- endfor -%}
+};
+
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
+
+{%- for operation in Operations -%}
+{% assign ResultType = operation.ResultType | prepend: 'Types.' %}
+{%- assign firstLetter = operation.ActualOperationName | slice: 0, 1 | upcase -%}
+    {% assign NonBodyParameters = operation.PathParameters | concat: operation.QueryParameters | concat: operation.HeaderParameters %}
+export function {{ operation.ActualOperationName }}Url({% for parameter in NonBodyParameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type | prepend: 'Types.' }}{{ parameter.TypePostfix }}{% unless forloop.last %}, {% endunless -%}{% endfor %}): string {
+  {% template Client.RequestUrl %}
+  return url_;
+}
+
+{%- if operation.HttpMethodUpper <> 'Get' -%}
+    {%- assign firstLetter = operation.ActualOperationName | slice: 0, 1 | upcase -%}
+    {%- if operation.FormParameters.size > 0 -%}
+      {%- assign TVariableType = operation.ActualOperationName | append: 'q' | slice: 1, operation.ActualOperationName.size | prepend: firstLetter | slice: 0, operation.ActualOperationName.size | append: MutationClassName | append: 'Parameters' -%}
+      {%- assign TVariableName = operation.ActualOperationName | append: MutationClassName | append: 'Parameters' -%}
+    {%- else -%}
+      {%- assign TVariableType = operation.ContentParameter.Type | default: 'void' | prepend: 'Types.' -%}
+      {%- assign TVariableName = operation.ContentParameter.VariableName -%}
+    {%- endif -%}
+export function {{ operation.ActualOperationName }}MutationKey({%- for parameter in NonBodyParameters -%}{%- assign ParameterType = parameter.Type | prepend: 'Types.' -%}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ ParameterType }}{{ parameter.TypePostfix }}{% unless forloop.last %}, {% endunless -%}{%- endfor -%}): MutationKey {
+  return trimArrayEnd([
+      '{{ Class }}',
+      '{{ operation.ActualOperationName }}',
+      {%- for parameter in NonBodyParameters -%}
+      {{ parameter.VariableName }} as any,
+      {%- endfor -%}
+    ]);
+}
+
+{% template Client.Method.Documentation %}
+export function {{ operation.MethodAccessModifier }}use{{ operation.ActualOperationName | capitalize }}Mutation<TContext>({%- for parameter in NonBodyParameters -%}{%- assign ParameterType = parameter.Type | prepend: 'Types.' -%}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ ParameterType }}{{ parameter.TypePostfix }}, {% endfor -%}options?: Omit<UseMutationOptions<{{ ResultType }}, unknown, {{ TVariableType }}, TContext>, 'mutationKey' | 'mutationFn'>): UseMutationResult<{{ ResultType }}, unknown, {{ TVariableType }}, TContext> {
+  const key = {{ operation.ActualOperationName }}MutationKey({%- for parameter in NonBodyParameters -%}{{ parameter.VariableName }}{% unless forloop.last %}, {% endunless -%}{% endfor -%});
+
+  const metaContext = useContext(QueryMetaContext);
+  options = addMetaToOptions(options, metaContext);
+
+  {%- if operation.FormParameters.size > 0 -%}
+      return useMutation(({{TVariableName}}: {{TVariableType}}) => {% template ReactQuery.GetClientCall %}.{% template OperationNameSafe %}({%- for parameter in operation.Parameters -%}
+      {%- assign isForm = false -%}
+      {%- for formParameter in operation.FormParameters -%}
+        {%- if parameter.Name == formParameter.Name -%}
+          {%- assign isForm = true -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {%- if isForm %}{{TVariableName}}.{{parameter.VariableName}}{% else %}{{ parameter.VariableName }}{% endif %}{% unless forloop.last %}, {% endunless -%}{% endfor -%}), {...options, mutationKey: key});
+  {%- else -%}
+      return useMutation(({% if operation.HasBody %}{{TVariableName}}: {{TVariableType}}{% endif %}) => {% template ReactQuery.GetClientCall %}.{% template OperationNameSafe %}({%- for parameter in operation.Parameters -%}{%- assign ParameterType = parameter.Type -%}{{ parameter.VariableName }}{% unless forloop.last %}, {% endunless -%}{% endfor -%}), {...options, mutationKey: key});
+  {%- endif -%}
+}
+{%- endif -%}
+{%- if operation.HttpMethodUpper == 'Get' -%}
+    {%- assign parameterClassName = operation.ActualOperationName | append: 'q' | slice: 1, operation.ActualOperationName.size | prepend: firstLetter | slice: 0, operation.ActualOperationName.size | append: QueryClassName | append: 'Parameters' -%}
+let {{ operation.ActualOperationName }}DefaultOptions: UseQueryOptions<{{ ResultType }}, unknown, {{ ResultType }}> = {
+  queryFn: __{{ operation.ActualOperationName }},
+};
+export function get{{ operation.ActualOperationName | capitalize }}DefaultOptions(): UseQueryOptions<{{ ResultType }}, unknown, {{ ResultType }}> {
+  return {{ operation.ActualOperationName }}DefaultOptions;
+};
+export function set{{ operation.ActualOperationName | capitalize }}DefaultOptions(options: UseQueryOptions<{{ ResultType }}, unknown, {{ ResultType }}>) {
+  {{ operation.ActualOperationName }}DefaultOptions = options;
+}
+
+{%- if operation.Parameters.size > 1 -%}
+export function {{ operation.ActualOperationName }}QueryKey(dto: {{ parameterClassName }}): QueryKey;
+{%- endif -%}
+export function {{ operation.ActualOperationName }}QueryKey({%- for parameter in operation.Parameters -%}{%- assign ParameterType = parameter.Type | prepend: 'Types.' -%}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ ParameterType }}{{ parameter.TypePostfix }}{% unless forloop.last %}, {% endunless -%}{%- endfor -%}): QueryKey;
+export function {{ operation.ActualOperationName }}QueryKey(...params: any[]): QueryKey {
+    {%- if operation.Parameters.size == 0 -%}
+  return trimArrayEnd([
+      '{{ Class }}',
+      '{{ operation.ActualOperationName }}',
+    ]);
+    {%- else -%}
+  if (params.length === 1 && isParameterObject(params[0])) {
+    const { {% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %} } = params[0] as {{ parameterClassName  }};
+
+    return trimArrayEnd([
+        '{{ Class }}',
+        '{{ operation.ActualOperationName }}',
+        {%- for parameter in operation.Parameters -%}
+        {{ parameter.VariableName }} as any,
+        {%- endfor -%}
+      ]);
+  } else {
+    return trimArrayEnd([
+        '{{ Class }}',
+        '{{ operation.ActualOperationName }}',
+        ...params
+      ]);
+  }
+    {%- endif -%}
+}
+{%- comment -%} Why add __ to the function name? see below where it's used {%- endcomment -%}
+function __{{ operation.ActualOperationName }}({% if operation.Parameters.size > 0 %}context: QueryFunctionContext{% endif %}) {
+  return {% template ReactQuery.GetClientCall %}.{{ operation.ActualOperationName }}(
+  {%- for parameter in operation.Parameters -%}
+{%- assign ParameterType = parameter.Type | prepend: 'Types.' -%}
+      context.queryKey[{{ forloop.index | plus: 1  }}] as {{ ParameterType }}{{ parameter.TypePostfix }}{% unless forloop.last %}, {% endunless -%}
+  {%- endfor -%}
+    );
+}
+
+    {%- if operation.Parameters.size > 0 -%}
+export function {{ operation.MethodAccessModifier }}use{{ operation.ActualOperationName | capitalize }}Query<TSelectData = {{ ResultType }}, TError = unknown>(dto: {{ parameterClassName }}, options?: UseQueryOptions<{{ ResultType }}, TError, TSelectData>): UseQueryResult<TSelectData, TError>;
+    {%- endif -%}
+{% template Client.Method.Documentation %}
+export function {{ operation.MethodAccessModifier }}use{{ operation.ActualOperationName | capitalize }}Query<TSelectData = {{ ResultType }}, TError = unknown>({%- for parameter in operation.Parameters -%}{%- assign ParameterType = parameter.Type | prepend: 'Types.' -%}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ ParameterType }}{{ parameter.TypePostfix }}, {% endfor %}options?: UseQueryOptions<{{ ResultType }}, TError, TSelectData>): UseQueryResult<TSelectData, TError>;
+export function use{{ operation.ActualOperationName | capitalize }}Query<TSelectData = {{ ResultType }}, TError = unknown>(...params: any []): UseQueryResult<TSelectData, TError> {
+  let options: UseQueryOptions<{{ ResultType }}, TError, TSelectData> | undefined = undefined;
+  {% for parameter in operation.Parameters %}let {{ parameter.VariableName }}: any = undefined;
+  {% endfor %}
+{%- if operation.Parameters.size > 0 -%}
+  if (params.length > 0) {
+    if (isParameterObject(params[0])) {
+      ({ {% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %} } = params[0] as {{ parameterClassName  }});
+      options = params[1];
+    } else {
+      [{% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %} options] = params;
+    }
+  }
+{% else %}
+  options = params[0] as any;
+{% endif %}
+
+  const metaContext = useContext(QueryMetaContext);
+  options = addMetaToOptions(options, metaContext);
+
+  return useQuery<{{ ResultType }}, TError, TSelectData>({
+    {%- comment -%} We add __ to the function name to avoid name clashing with parameters of this function {%- endcomment -%}
+    queryFn: __{{ operation.ActualOperationName }},
+    queryKey: {{ operation.ActualOperationName }}QueryKey({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% unless forloop.last %}, {% endunless -%}{% endfor %}),
+    ...{{ operation.ActualOperationName }}DefaultOptions as unknown as UseQueryOptions<{{ ResultType }}, TError, TSelectData>,
+    ...options,
+  });
+}
+{% template Client.Method.Documentation %}
+export function {{ operation.MethodAccessModifier }}set{{ operation.ActualOperationName | capitalize }}Data(queryClient: QueryClient, updater: (data: {{ ResultType }} | undefined) => {{ ResultType }}, {% for parameter in operation.Parameters -%}{%- assign ParameterType = parameter.Type | prepend: 'Types.' -%}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ ParameterType }}{{ parameter.TypePostfix }}{% unless forloop.last %}, {% endunless -%}{% endfor %}) {
+  queryClient.setQueryData({{ operation.ActualOperationName }}QueryKey({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% unless forloop.last %}, {% endunless -%}{% endfor %}),
+    updater
+  );
+}
+
+{% template Client.Method.Documentation %}
+export function {{ operation.MethodAccessModifier }}set{{ operation.ActualOperationName | capitalize }}DataByQueryId(queryClient: QueryClient, queryKey: QueryKey, updater: (data: {{ ResultType }} | undefined) => {{ ResultType }}) {
+  queryClient.setQueryData(queryKey, updater);
+}
+  {% endif -%}
+  {% endfor -%}
+
+{% endif -%}

--- a/src/templates_vue/ReactQueryFile.liquid
+++ b/src/templates_vue/ReactQueryFile.liquid
@@ -6,6 +6,7 @@ export { setAxiosFactory, getAxios } from './helpers';
 export { setFetchFactory, getFetch } from './helpers';
 {%- endif -%}
 //-----ReactQueryFile-----
+import { isRef } from 'vue';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import type { UseQueryResult, QueryFunctionContext, UseQueryOptions, QueryClient, QueryKey, MutationKey, UseMutationOptions, UseMutationResult, QueryMeta, MutationMeta } from '@tanstack/react-query';
 {% template ReactQuery.MetaFile %}
@@ -51,7 +52,7 @@ export function isParameterObject(param: unknown) {
     const isObject = typeof param === 'object';
     if (!isObject) return false;
     if (param instanceof Date) return false;
-    return true;
+    return !isRef(param);
 }
 
 let _baseUrl = '';


### PR DESCRIPTION
Allows to use refs which is really useful

Consider such example

```js
const { data: todos, isFetched: areTodosFetched } = useGetTodosQuery();

const firstTodoId = computed(() => (areTodosFetched.value && todos.value?.[0]
  ? todos.value[0].id
  : undefined));

const { data: firstTodoNotes } = useGetTodoNotesQuery({ id: firstTodoId }, { enabled: areTodosFetched });
```

The second request will be triggered only after the first one is finished. So, we will know todo's id later only and using `ref` it becomes reactive 