### PR TITLE
fix: `fix-null-undefined-serialization` doesn't replace undefined with null

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -190,7 +190,8 @@ if (args.includes('/fix-null-undefined-serialization')) {
   //   id?: number | undefined;   ->  id?: number | null;
   // }
   // Replaced because this is what server (at least .NET :)) actually returns
-  apiClient = apiClient.replaceAll('| undefined;', '| null;');
+  apiClient = apiClient.replaceAll(/\| undefined\s*;/g, '| null;');
+  apiClient = apiClient.replaceAll('| null | null;', '| null;');
 
   /* this changes `init()` function to be like:
    * this.lastChangeDateTime = _data["lastChangeDateTime"] ? new Date(_data["lastChangeDateTime"].toString()) : <any>undefined;


### PR DESCRIPTION
For some reason, NSwag started producing a space between `undedined` and `;`, so the old pattern doesn't match anymore.

In several files I've saw the comment:
```
{% comment %}space before the ';' is important, so that 'undefined' here is not replaced with null{% endcomment %}
```
But in my project I haven't noticed any unexpected replacing of `undefined` with `null` after these changes.