### PR TITLE
Add ability to specify self-managed template directory

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -30,9 +30,18 @@ const noHooks = args.includes('/no-hooks');
 const useRecommendedConfiguration =
   args.includes('/use-recommended-configuration') || isMinimal;
 
+  
 let pathToTemplates = process.mainModule.filename
   .replace('cli.js', 'templates')
   .replace('.bin/react-query-swagger', 'react-query-swagger/templates');
+  
+//if the user specified a template directory, use that instead
+const templateDirRegex = args.match(/\/templateDirectory:"(?<path>.*?)"/) || args.match(/\/templateDirectory:(?<path>\S*)/);
+const templateDir = templateDirRegex?.groups?.['path'];
+console.log('TEMPLATE DIRECTORY: ' + templateDir);
+if (templateDir) {
+  pathToTemplates = templateDir;
+}
 
 if (isVue) {
   pathToTemplates = pathToTemplates.replace(/templates$/, 'templates_vue');


### PR DESCRIPTION
Hi,

I'm looking to add the ability to specify my own template directory so I can make customizations on top of your liquid templates. Some of these I intend to bring back, e.g. Vue3 reactivity enhancements.

Usage:
`/templateDirectory:./my-templates`