### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "git://github.com/shaddix/react-query-swagger.git"
   },
+  "bugs": {
+    "url": "https://github.com/shaddix/react-query-swagger/issues"
+  },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `react-query-swagger`
- point the metadata at the repository GitHub issues page
- leave runtime code, dependencies, version, and package contents unchanged

## Validation
- `node -e "const p=require('./src/package.json'); ..."`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./src`